### PR TITLE
exclude CLAUDE.md and README.md from jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,6 @@ markdown: kramdown
 highlighter: rouge
 kramdown:
   input: GFM
+exclude:
+  - CLAUDE.md
+  - README.md


### PR DESCRIPTION
## Summary
- Add `exclude:` list to `_config.yml` so Jekyll skips `CLAUDE.md` and `README.md`.
- Fixes a build failure where Jekyll's Liquid parser tried to render `{% for ... %}` examples inside `CLAUDE.md` code spans and aborted with `'for' tag was never closed`.
- Also stops `README.md` from being rendered into `_site/README.html`, which served no purpose.

## Test plan
- [ ] `bundle exec jekyll serve` starts cleanly without the Liquid syntax error
- [ ] `_site/` no longer contains `README.html` or anything derived from `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)