### PR TITLE
remove stale data-theme="dark" from <body>

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -137,7 +137,7 @@
       });
     </script>
   </head>
-  <body data-theme="dark">
+  <body>
     {% include navigation.html %} {{ content }} {% include footer.html %}
     <script src='{{ "/assets/js/theme-switcher.js" | relative_url }}'></script>
   </body>


### PR DESCRIPTION
## Summary
- The theme is set on `<html>` by the inline bootstrap script in `<head>`, and all CSS selectors target `html[data-theme=...]`.
- The `data-theme="dark"` on `<body>` was a no-op left behind from an earlier iteration. Removing it.

## Test plan
- [ ] Each theme still applies correctly across pages (light + dark themes both)
- [ ] Theme switcher in the footer still updates the page live

🤖 Generated with [Claude Code](https://claude.com/claude-code)