### PR TITLE
gate mathjax behind page.math front matter

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -107,6 +107,7 @@
     <!-- BOOTSTRAP 5 JS REMOVED — no Bootstrap JS components were used -->
     <!-- ============================================================ -->
     <!--<script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js' integrity='sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO' crossorigin='anonymous'></script>-->
+    {% if page.math %}
     <script>
       window.MathJax = {
         tex: {
@@ -128,6 +129,7 @@
       async
       src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
     ></script>
+    {% endif %}
     <script>
       document.addEventListener("DOMContentLoaded", function () {
         document.querySelectorAll("a[href^='http']").forEach(function (link) {

--- a/_posts/2018-08-19-stirlings-pogs.md
+++ b/_posts/2018-08-19-stirlings-pogs.md
@@ -4,6 +4,7 @@ title: "Stirling's Pogs"
 date: 2018-08-19
 permalink: /posts/stirlings-pogs
 excerpt: "1990s Spawn pogs, the multinomial distribution, and Stirling numbers of the second kind."
+math: true
 ---
 ## Why are we talking about pogs?
 


### PR DESCRIPTION
## Summary
- MathJax (~140 KB) was loading on every page, but only `stirlings-pogs` (and the in-progress `basketball-variance` draft) actually uses math.
- Wrap both MathJax `<script>` tags in `{% if page.math %}…{% endif %}` so the load is opt-in per page.
- Add `math: true` to the front matter of `_posts/2018-08-19-stirlings-pogs.md`.

Future math-using posts just need `math: true` in their front matter.

## Test plan
- [ ] `/posts/stirlings-pogs` renders math correctly (and DevTools shows MathJax loading)
- [ ] Any non-math page (e.g. `/`, `/posts`, `/posts/stephen-ai-smith`) does NOT load MathJax (confirm in DevTools network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)