### PR TITLE
remove stale BOOTSTRAP REMOVED banner comments

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,11 +18,6 @@
     <title>{{ page.title }}</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- ============================================================ -->
-    <!-- BOOTSTRAP 5 REMOVED — utility classes now defined in base.css -->
-    <!-- ============================================================ -->
-    <!--- BOOTSTRAP 5 --->
-    <!--<link href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css' rel='stylesheet' integrity='sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT' crossorigin='anonymous'>-->
     <!-- FONTS -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -103,10 +98,6 @@
       var favicon_path = "/assets/images/" + season + ".ico";
       document.getElementById("favicon").setAttribute("href", favicon_path);
     </script>
-    <!-- ============================================================ -->
-    <!-- BOOTSTRAP 5 JS REMOVED — no Bootstrap JS components were used -->
-    <!-- ============================================================ -->
-    <!--<script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js' integrity='sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO' crossorigin='anonymous'></script>-->
     {% if page.math %}
     <script>
       window.MathJax = {


### PR DESCRIPTION
## Summary
- The Bootstrap migration landed in 2516c84; the two banner blocks plus their commented-out `<link>`/`<script>` tags were left behind as audit trail.
- Several commits later, the change is verified working — the historical record lives in git, not the layout. Removing the dead comments.

## Test plan
- [ ] Site still renders identically (no visual or behavioral change expected; pure comment removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)